### PR TITLE
feat: improve skill scores + add Tessl skill review workflow

### DIFF
--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,0 +1,22 @@
+# Tessl Skill Review — runs on PRs that change any SKILL.md; posts scores as one PR comment.
+# Docs: https://github.com/tesslio/skill-review
+name: Tessl Skill Review
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/SKILL.md"
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/skill-review@main
+      # Optional quality gate (off by default — do not enable unless user asked):
+      # with:
+      #   fail-threshold: 70

--- a/application/plugins/enterprise-search/skills/knowledge-synthesis/SKILL.md
+++ b/application/plugins/enterprise-search/skills/knowledge-synthesis/SKILL.md
@@ -1,28 +1,27 @@
 ---
 name: knowledge-synthesis
-description: Combines search results from multiple sources into coherent, deduplicated answers with source attribution. Handles confidence scoring based on freshness and authority, and summarizes large result sets effectively.
+description: "Combines search results from multiple sources into coherent, deduplicated answers with source attribution. Use when combining results from multiple search queries, aggregating information from different sources, merging findings, or when the user needs deduplicated summaries with citations. Handles confidence scoring based on freshness and authority, and summarizes large result sets effectively."
 ---
 
 # Knowledge Synthesis
 
 The last mile of enterprise search. Takes raw results from multiple sources and produces a coherent, trustworthy answer.
 
-## The Goal
+## Example
 
-Transform this:
+**Raw input** (multiple source results):
 ```
-~~chat result: "Sarah said in #eng: 'let's go with REST, GraphQL is overkill for our use case'"
-~~email result: "Subject: API Decision — Sarah's email confirming REST approach with rationale"
-~~cloud storage result: "API Design Doc v3 — updated section 2 to reflect REST decision"
-~~project tracker result: "Task: Finalize API approach — marked complete by Sarah"
+~~chat: "Sarah said in #eng: 'let's go with REST, GraphQL is overkill'"
+~~email: "Subject: API Decision — Sarah confirming REST approach"
+~~cloud storage: "API Design Doc v3 — updated to reflect REST decision"
+~~project tracker: "Task: Finalize API approach — marked complete by Sarah"
 ```
 
-Into this:
+**Synthesized output:**
 ```
-The team decided to go with REST over GraphQL for the API redesign. Sarah made the
-call, noting that GraphQL was overkill for the current use case. This was discussed
-in #engineering on Tuesday, confirmed via email Wednesday, and the design doc has
-been updated to reflect the decision. The related ~~project tracker task is marked complete.
+The team decided to go with REST over GraphQL. Sarah made the call, noting
+GraphQL was overkill. Discussed in #engineering Tuesday, confirmed via email
+Wednesday, and the design doc is updated.
 
 Sources:
 - ~~chat: #engineering thread (Jan 14)
@@ -31,227 +30,62 @@ Sources:
 - ~~project tracker: "Finalize API approach" (completed Jan 15)
 ```
 
-## Deduplication
-
-### Cross-Source Deduplication
-
-The same information often appears in multiple places. Identify and merge duplicates:
-
-**Signals that results are about the same thing:**
-- Same or very similar text content
-- Same author/sender
-- Timestamps within a short window (same day or adjacent days)
-- References to the same entity (project name, document, decision)
-- One source references another ("as discussed in ~~chat", "per the email", "see the doc")
-
-**How to merge:**
-- Combine into a single narrative item
-- Cite all sources where it appeared
-- Use the most complete version as the primary text
-- Add unique details from each source
-
-### Deduplication Priority
-
-When the same information exists in multiple sources, prefer:
-```
-1. The most complete version (fullest context)
-2. The most authoritative source (official doc > chat)
-3. The most recent version (latest update wins for evolving info)
-```
-
-### What NOT to Deduplicate
-
-Keep as separate items when:
-- The same topic is discussed but with different conclusions
-- Different people express different viewpoints
-- The information evolved meaningfully between sources (v1 vs v2 of a decision)
-- Different time periods are represented
-
-## Citation and Source Attribution
-
-Every claim in the synthesized answer must be attributable to a source.
-
-### Attribution Format
-
-Inline for direct references:
-```
-Sarah confirmed the REST approach in her email on Wednesday.
-The design doc was updated to reflect this (~~cloud storage: "API Design Doc v3").
-```
-
-Source list at the end for completeness:
-```
-Sources:
-- ~~chat: #engineering discussion (Jan 14) — initial decision thread
-- ~~email: "API Decision" from Sarah Chen (Jan 15) — formal confirmation
-- ~~cloud storage: "API Design Doc v3" last modified Jan 15 — updated specification
-```
-
-### Attribution Rules
-
-- Always name the source type (~~chat, ~~email, ~~cloud storage, etc.)
-- Include the specific location (channel, folder, thread)
-- Include the date or relative time
-- Include the author when relevant
-- Include document/thread titles when available
-- For ~~chat, note the channel name
-- For ~~email, note the subject line and sender
-- For ~~cloud storage, note the document title
-
-## Confidence Levels
-
-Not all results are equally trustworthy. Assess confidence based on:
-
-### Freshness
-
-| Recency | Confidence impact |
-|---------|------------------|
-| Today / yesterday | High confidence for current state |
-| This week | Good confidence |
-| This month | Moderate — things may have changed |
-| Older than a month | Lower confidence — flag as potentially outdated |
-
-For status queries, heavily weight freshness. For policy/factual queries, freshness matters less.
-
-### Authority
-
-| Source type | Authority level |
-|-------------|----------------|
-| Official wiki / knowledge base | Highest — curated, maintained |
-| Shared documents (final versions) | High — intentionally published |
-| Email announcements | High — formal communication |
-| Meeting notes | Moderate-high — may be incomplete |
-| Chat messages (thread conclusions) | Moderate — informal but real-time |
-| Chat messages (mid-thread) | Lower — may not reflect final position |
-| Draft documents | Low — not finalized |
-| Task comments | Contextual — depends on commenter |
-
-### Expressing Confidence
-
-When confidence is high (multiple fresh, authoritative sources agree):
-```
-The team decided to use REST for the API redesign. [direct statement]
-```
-
-When confidence is moderate (single source or somewhat dated):
-```
-Based on the discussion in #engineering last month, the team was leaning
-toward REST for the API redesign. This may have evolved since then.
-```
-
-When confidence is low (old data, informal source, or conflicting signals):
-```
-I found a reference to an API migration discussion from three months ago
-in ~~chat, but I couldn't find a formal decision document. The information
-may be outdated. You might want to check with the team for current status.
-```
-
-### Conflicting Information
-
-When sources disagree:
-```
-I found conflicting information about the API approach:
-- The ~~chat discussion on Jan 10 suggested GraphQL
-- But Sarah's email on Jan 15 confirmed REST
-- The design doc (updated Jan 15) reflects REST
-
-The most recent sources indicate REST was the final decision,
-but the earlier ~~chat discussion explored GraphQL first.
-```
-
-Always surface conflicts rather than silently picking one version.
-
-## Summarization Strategies
-
-### For Small Result Sets (1-5 results)
-
-Present each result with context. No summarization needed — give the user everything:
-```
-[Direct answer synthesized from results]
-
-[Detail from source 1]
-[Detail from source 2]
-
-Sources: [full attribution]
-```
-
-### For Medium Result Sets (5-15 results)
-
-Group by theme and summarize each group:
-```
-[Overall answer]
-
-Theme 1: [summary of related results]
-Theme 2: [summary of related results]
-
-Key sources: [top 3-5 most relevant sources]
-Full results: [count] items found across [sources]
-```
-
-### For Large Result Sets (15+ results)
-
-Provide a high-level synthesis with the option to drill down:
-```
-[Overall answer based on most relevant results]
-
-Summary:
-- [Key finding 1] (supported by N sources)
-- [Key finding 2] (supported by N sources)
-- [Key finding 3] (supported by N sources)
-
-Top sources:
-- [Most authoritative/relevant source]
-- [Second most relevant]
-- [Third most relevant]
-
-Found [total count] results across [source list].
-Want me to dig deeper into any specific aspect?
-```
-
-### Summarization Rules
-
-- Lead with the answer, not the search process
-- Do not list raw results — synthesize them into narrative
-- Group related items from different sources together
-- Preserve important nuance and caveats
-- Include enough detail that the user can decide whether to dig deeper
-- Always offer to provide more detail if the result set was large
-
 ## Synthesis Workflow
 
-```
-[Raw results from all sources]
-          ↓
-[1. Deduplicate — merge same info from different sources]
-          ↓
-[2. Cluster — group related results by theme/topic]
-          ↓
-[3. Rank — order clusters and items by relevance to query]
-          ↓
-[4. Assess confidence — freshness × authority × agreement]
-          ↓
-[5. Synthesize — produce narrative answer with attribution]
-          ↓
-[6. Format — choose appropriate detail level for result count]
-          ↓
-[Coherent answer with sources]
-```
+1. **Deduplicate** — merge same info from different sources
+2. **Cluster** — group related results by theme/topic
+3. **Rank** — order clusters by relevance to query
+4. **Assess confidence** — freshness × authority × agreement
+5. **Synthesize** — produce narrative answer with attribution
+6. **Format** — choose detail level based on result count
+
+## Deduplication
+
+**Duplicate signals:** same/similar text, same author, timestamps within a short window, references to the same entity, cross-references between sources.
+
+**Merge strategy:** combine into a single narrative item, cite all sources, use the most complete version as primary, add unique details from each.
+
+**Priority:** most complete version > most authoritative source (official doc > chat) > most recent version.
+
+**Do NOT deduplicate** when: different conclusions exist, different viewpoints are expressed, information evolved meaningfully between sources, or different time periods are represented.
+
+## Source Attribution
+
+Every claim must be attributable. Use inline attribution for direct references and a source list at the end.
+
+**Always include:** source type (~~chat, ~~email, etc.), specific location (channel, folder), date/relative time, author when relevant, document/thread titles when available.
+
+## Confidence Scoring
+
+| Freshness | Confidence |
+|-----------|-----------|
+| Today/yesterday | High |
+| This week | Good |
+| This month | Moderate — flag as possibly changed |
+| Older than a month | Lower — flag as potentially outdated |
+
+| Source Type | Authority |
+|-------------|----------|
+| Official wiki/knowledge base | Highest |
+| Shared documents (final) | High |
+| Email announcements | High |
+| Meeting notes | Moderate-high |
+| Chat thread conclusions | Moderate |
+| Chat mid-thread | Lower |
+| Drafts | Low |
+
+**Express confidence explicitly:** direct statements for high confidence, hedging language for moderate, and suggest verification for low confidence. Always surface conflicts rather than silently picking one version.
+
+## Summarization by Result Count
+
+- **1–5 results:** Present each with full context and attribution.
+- **5–15 results:** Group by theme, summarize each group, cite top 3–5 sources.
+- **15+ results:** High-level synthesis with key findings, top sources, total count, and offer to drill deeper.
 
 ## Anti-Patterns
 
-**Do not:**
-- List results source by source ("From ~~chat: ... From ~~email: ... From ~~cloud storage: ...")
-- Include irrelevant results just because they matched a keyword
-- Bury the answer under methodology explanation
-- Present conflicting info without flagging the conflict
-- Omit source attribution
-- Present uncertain information with the same confidence as well-supported facts
-- Summarize so aggressively that useful detail is lost
-
-**Do:**
-- Lead with the answer
+- Lead with the answer, not the search process
 - Group by topic, not by source
-- Flag confidence levels when appropriate
-- Surface conflicts explicitly
-- Attribute all claims to sources
-- Offer to go deeper when result sets are large
+- Never omit attribution or bury the answer under methodology
+- Surface conflicts explicitly — never silently pick one version
+- Do not include irrelevant keyword matches

--- a/application/plugins/enterprise-search/skills/search-strategy/SKILL.md
+++ b/application/plugins/enterprise-search/skills/search-strategy/SKILL.md
@@ -1,51 +1,31 @@
 ---
 name: search-strategy
-description: Query decomposition and multi-source search orchestration. Breaks natural language questions into targeted searches per source, translates queries into source-specific syntax, ranks results by relevance, and handles ambiguity and fallback strategies.
+description: "Query decomposition and multi-source search orchestration. Use when the user wants to search multiple sources, find information across databases, look up in different places, or combine search results. Breaks natural language questions into targeted searches per source, translates queries into source-specific syntax, ranks results by relevance, and handles ambiguity and fallback strategies."
 ---
 
 # Search Strategy
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> For connector details and tool references, see [CONNECTORS.md](../../CONNECTORS.md).
 
-The core intelligence behind enterprise search. Transforms a single natural language question into parallel, source-specific searches and produces ranked, deduplicated results.
-
-## The Goal
-
-Turn this:
-```
-"What did we decide about the API migration timeline?"
-```
-
-Into targeted searches across every connected source:
-```
-~~chat:  "API migration timeline decision" (semantic) + "API migration" in:#engineering after:2025-01-01
-~~knowledge base: semantic search "API migration timeline decision"
-~~project tracker:  text search "API migration" in relevant workspace
-```
-
-Then synthesize the results into a single coherent answer.
+Transforms a single natural language question into parallel, source-specific searches and produces ranked, deduplicated results.
 
 ## Query Decomposition
 
 ### Step 1: Identify Query Type
 
-Classify the user's question to determine search strategy:
-
 | Query Type | Example | Strategy |
 |-----------|---------|----------|
 | **Decision** | "What did we decide about X?" | Prioritize conversations (~~chat, email), look for conclusion signals |
-| **Status** | "What's the status of Project Y?" | Prioritize recent activity, task trackers, status updates |
+| **Status** | "What's the status of Project Y?" | Prioritize recent activity, task trackers |
 | **Document** | "Where's the spec for Z?" | Prioritize Drive, wiki, shared docs |
 | **Person** | "Who's working on X?" | Search task assignments, message authors, doc collaborators |
-| **Factual** | "What's our policy on X?" | Prioritize wiki, official docs, then confirmatory conversations |
-| **Temporal** | "When did X happen?" | Search with broad date range, look for timestamps |
-| **Exploratory** | "What do we know about X?" | Broad search across all sources, synthesize |
+| **Factual** | "What's our policy on X?" | Prioritize wiki, official docs |
+| **Temporal** | "When did X happen?" | Broad date range, look for timestamps |
+| **Exploratory** | "What do we know about X?" | Broad search across all sources |
 
 ### Step 2: Extract Search Components
 
-From the query, extract:
-
-- **Keywords**: Core terms that must appear in results
+- **Keywords**: Core terms that must appear
 - **Entities**: People, projects, teams, tools (use memory system if available)
 - **Intent signals**: Decision words, status words, temporal markers
 - **Constraints**: Time ranges, source hints, author filters
@@ -53,19 +33,9 @@ From the query, extract:
 
 ### Step 3: Generate Sub-Queries Per Source
 
-For each available source, create one or more targeted queries:
+**Semantic search** for conceptual/exploratory questions where exact keywords are unknown. **Keyword search** for known terms, exact phrases, and filter-heavy queries.
 
-**Prefer semantic search** for:
-- Conceptual questions ("What do we think about...")
-- Questions where exact keywords are unknown
-- Exploratory queries
-
-**Prefer keyword search** for:
-- Known terms, project names, acronyms
-- Exact phrases the user quoted
-- Filter-heavy queries (from:, in:, after:)
-
-**Generate multiple query variants** when the topic might be referred to differently:
+Generate multiple query variants when the topic might be referred to differently:
 ```
 User: "Kubernetes setup"
 Queries: "Kubernetes", "k8s", "cluster", "container orchestration"
@@ -75,20 +45,7 @@ Queries: "Kubernetes", "k8s", "cluster", "container orchestration"
 
 ### ~~chat
 
-**Semantic search** (natural language questions):
-```
-query: "What is the status of project aurora?"
-```
-
-**Keyword search:**
-```
-query: "project aurora status update"
-query: "aurora in:#engineering after:2025-01-15"
-query: "from:<@UserID> aurora"
-```
-
-**Filter mapping:**
-| Enterprise filter | ~~chat syntax |
+| Enterprise Filter | ~~chat Syntax |
 |------------------|--------------|
 | `from:sarah` | `from:sarah` or `from:<@USERID>` |
 | `in:engineering` | `in:engineering` |
@@ -99,29 +56,12 @@ query: "from:<@UserID> aurora"
 
 ### ~~knowledge base (Wiki)
 
-**Semantic search** — Use for conceptual queries:
-```
-descriptive_query: "API migration timeline and decision rationale"
-```
-
-**Keyword search** — Use for exact terms:
-```
-query: "API migration"
-query: "\"API migration timeline\""  (exact phrase)
-```
+Semantic: `descriptive_query: "API migration timeline and decision rationale"`
+Keyword: `query: "API migration"` or `"\"exact phrase\""`
 
 ### ~~project tracker
 
-**Task search:**
-```
-text: "API migration"
-workspace: [workspace_id]
-completed: false  (for status queries)
-assignee_any: "me"  (for "my tasks" queries)
-```
-
-**Filter mapping:**
-| Enterprise filter | ~~project tracker parameter |
+| Enterprise Filter | ~~project tracker Parameter |
 |------------------|----------------|
 | `from:sarah` | `assignee_any` or `created_by_any` |
 | `after:2025-01-01` | `modified_on_after: "2025-01-01"` |
@@ -129,93 +69,28 @@ assignee_any: "me"  (for "my tasks" queries)
 
 ## Result Ranking
 
-### Relevance Scoring
+Score each result weighted by query type:
 
-Score each result on these factors (weighted by query type):
-
-| Factor | Weight (Decision) | Weight (Status) | Weight (Document) | Weight (Factual) |
-|--------|-------------------|------------------|--------------------|-------------------|
+| Factor | Decision | Status | Document | Factual |
+|--------|----------|--------|----------|---------|
 | Keyword match | 0.3 | 0.2 | 0.4 | 0.3 |
 | Freshness | 0.3 | 0.4 | 0.2 | 0.1 |
 | Authority | 0.2 | 0.1 | 0.3 | 0.4 |
 | Completeness | 0.2 | 0.3 | 0.1 | 0.2 |
 
-### Authority Hierarchy
-
-Depends on query type:
-
-**For factual/policy questions:**
-```
-Wiki/Official docs > Shared documents > Email announcements > Chat messages
-```
-
-**For "what happened" / decision questions:**
-```
-Meeting notes > Thread conclusions > Email confirmations > Chat messages
-```
-
-**For status questions:**
-```
-Task tracker > Recent chat > Status docs > Email updates
-```
+**Authority hierarchy** varies by query type: wiki/official docs rank highest for factual queries; meeting notes and thread conclusions rank highest for decisions; task tracker ranks highest for status.
 
 ## Handling Ambiguity
 
-When a query is ambiguous, prefer asking one focused clarifying question over guessing:
-
-```
-Ambiguous: "search for the migration"
-→ "I found references to a few migrations. Are you looking for:
-   1. The database migration (Project Phoenix)
-   2. The cloud migration (AWS → GCP)
-   3. The email migration (Exchange → O365)"
-```
-
-Only ask for clarification when:
-- There are genuinely distinct interpretations that would produce very different results
-- The ambiguity would significantly affect which sources to search
-
-Do NOT ask for clarification when:
-- The query is clear enough to produce useful results
-- Minor ambiguity can be resolved by returning results from multiple interpretations
+Ask one focused clarifying question only when genuinely distinct interpretations would produce very different results. Do not ask when the query is clear enough or minor ambiguity can be resolved by returning results from multiple interpretations.
 
 ## Fallback Strategies
 
-When a source is unavailable or returns no results:
-
-1. **Source unavailable**: Skip it, search remaining sources, note the gap
-2. **No results from a source**: Try broader query terms, remove date filters, try alternate keywords
-3. **All sources return nothing**: Suggest query modifications to the user
-4. **Rate limited**: Note the limitation, return results from other sources, suggest retrying later
-
-### Query Broadening
-
-If initial queries return too few results:
-```
-Original: "PostgreSQL migration Q2 timeline decision"
-Broader:  "PostgreSQL migration"
-Broader:  "database migration"
-Broadest: "migration"
-```
-
-Remove constraints in this order:
-1. Date filters (search all time)
-2. Source/location filters
-3. Less important keywords
-4. Keep only core entity/topic terms
+1. **Source unavailable**: Skip, search remaining sources, note the gap
+2. **No results**: Broaden — remove date filters, then location filters, then less important keywords
+3. **All empty**: Suggest query modifications
+4. **Rate limited**: Return results from other sources, suggest retrying later
 
 ## Parallel Execution
 
-Always execute searches across sources in parallel, never sequentially. The total search time should be roughly equal to the slowest single source, not the sum of all sources.
-
-```
-[User query]
-     ↓ decompose
-[~~chat query] [~~email query] [~~cloud storage query] [Wiki query] [~~project tracker query]
-     ↓            ↓            ↓              ↓            ↓
-  (parallel execution)
-     ↓
-[Merge + Rank + Deduplicate]
-     ↓
-[Synthesized answer]
-```
+Always execute searches across sources in parallel. Total search time should equal the slowest single source, not the sum of all sources.

--- a/application/plugins/enterprise-search/skills/source-management/SKILL.md
+++ b/application/plugins/enterprise-search/skills/source-management/SKILL.md
@@ -1,172 +1,65 @@
 ---
 name: source-management
-description: Manages connected MCP sources for enterprise search. Detects available sources, guides users to connect new ones, handles source priority ordering, and manages rate limiting awareness.
+description: "Manages connected MCP sources for enterprise search. Use when users ask about connecting data sources, managing search integrations, troubleshooting search connections, checking which sources are available, or configuring enterprise search connectors. Detects available sources, guides users to connect new ones, handles source priority ordering, and manages rate limiting awareness."
 ---
 
 # Source Management
 
-> If you see unfamiliar placeholders or need to check which tools are connected, see [CONNECTORS.md](../../CONNECTORS.md).
+> For connector details and tool references, see [CONNECTORS.md](../../CONNECTORS.md).
 
-Knows what sources are available, helps connect new ones, and manages how sources are queried.
+Manages what MCP sources are available, helps connect new ones, and orchestrates how sources are queried.
 
-## Checking Available Sources
+## Available Sources
 
-Determine which MCP sources are connected by checking available tools. Each source corresponds to a set of MCP tools:
+Each source corresponds to MCP tool prefixes. If the prefix is available, the source is connected:
 
-| Source | Key capabilities |
+| Source | Key Capabilities |
 |--------|-----------------|
-| **~~chat** | Search messages, read channels and threads |
-| **~~email** | Search messages, read individual emails |
+| **~~chat** | Search messages, read channels/threads |
+| **~~email** | Search messages, read emails |
 | **~~cloud storage** | Search files, fetch document contents |
 | **~~project tracker** | Search tasks, typeahead search |
-| **~~CRM** | Query records (accounts, contacts, opportunities) |
+| **~~CRM** | Query accounts, contacts, opportunities |
 | **~~knowledge base** | Semantic search, keyword search |
 
-If a tool prefix is available, the source is connected and searchable.
+## Connecting Sources
 
-## Guiding Users to Connect Sources
-
-When a user searches but has few or no sources connected:
-
-```
-You currently have [N] source(s) connected: [list].
-
-To expand your search, you can connect additional sources in your MCP settings:
-- ~~chat — messages, threads, channels
-- ~~email — emails, conversations, attachments
-- ~~cloud storage — docs, sheets, slides
-- ~~project tracker — tasks, projects, milestones
-- ~~CRM — accounts, contacts, opportunities
-- ~~knowledge base — wiki pages, knowledge base articles
-
-The more sources you connect, the more complete your search results.
-```
-
-When a user asks about a specific tool that is not connected:
+When a user has few/no sources connected, list available sources and guide them to MCP settings. When a specific tool is not connected:
 
 ```
 [Tool name] isn't currently connected. To add it:
 1. Open your MCP settings
 2. Add the [tool] MCP server configuration
 3. Authenticate when prompted
-
-Once connected, it will be automatically included in future searches.
 ```
 
-## Source Priority Ordering
+To add custom sources: add MCP server configuration to `.mcp.json`, authenticate if required — search/digest commands auto-detect new sources.
 
-Different query types benefit from searching certain sources first. Use these priorities to weight results, not to skip sources:
+## Source Priority by Query Type
 
-### By Query Type
+Use priorities to weight results, not to skip sources:
 
-**Decision queries** ("What did we decide..."):
-```
-1. ~~chat (conversations where decisions happen)
-2. ~~email (decision confirmations, announcements)
-3. ~~cloud storage (meeting notes, decision logs)
-4. Wiki (if decisions are documented)
-5. Task tracker (if decisions are captured in tasks)
-```
+| Query Type | Priority Order (highest first) |
+|------------|-------------------------------|
+| **Decision** ("What did we decide...") | ~~chat → ~~email → ~~cloud storage → wiki → tracker |
+| **Status** ("What's the status...") | ~~project tracker → ~~chat → ~~cloud storage → ~~email → wiki |
+| **Document** ("Where's the doc...") | ~~cloud storage → wiki/~~knowledge base → ~~email → ~~chat → tracker |
+| **People** ("Who works on...") | ~~chat → tracker → ~~cloud storage → ~~CRM → ~~email |
+| **Factual/Policy** ("What's our policy...") | wiki/~~knowledge base → ~~cloud storage → ~~email → ~~chat |
+| **General** (unclear type) | ~~chat → ~~email → ~~cloud storage → wiki → tracker → CRM |
 
-**Status queries** ("What's the status of..."):
-```
-1. Task tracker (~~project tracker — authoritative status)
-2. ~~chat (real-time discussion)
-3. ~~cloud storage (status docs, reports)
-4. ~~email (status update emails)
-5. Wiki (project pages)
-```
+## Rate Limiting
 
-**Document queries** ("Where's the doc for..."):
-```
-1. ~~cloud storage (primary doc storage)
-2. Wiki / ~~knowledge base (knowledge base)
-3. ~~email (docs shared via email)
-4. ~~chat (docs shared in channels)
-5. Task tracker (docs linked to tasks)
-```
+**Detection:** HTTP 429, "rate limit"/"too many requests"/"quota exceeded" errors, throttled responses.
 
-**People queries** ("Who works on..." / "Who knows about..."):
-```
-1. ~~chat (message authors, channel members)
-2. Task tracker (task assignees)
-3. ~~cloud storage (doc authors, collaborators)
-4. ~~CRM (account owners, contacts)
-5. ~~email (email participants)
-```
+**Handling:**
+1. Do not retry immediately — respect the limit
+2. Continue with other sources — do not block the entire search
+3. Inform the user which source is limited and that results are partial
+4. For digests: note which time range was covered before the limit
 
-**Factual/Policy queries** ("What's our policy on..."):
-```
-1. Wiki / ~~knowledge base (official documentation)
-2. ~~cloud storage (policy docs, handbooks)
-3. ~~email (policy announcements)
-4. ~~chat (policy discussions)
-```
-
-### Default Priority (General Queries)
-
-When query type is unclear:
-```
-1. ~~chat (highest volume, most real-time)
-2. ~~email (formal communications)
-3. ~~cloud storage (documents and files)
-4. Wiki / ~~knowledge base (structured knowledge)
-5. Task tracker (work items)
-6. CRM (customer data)
-```
-
-## Rate Limiting Awareness
-
-MCP sources may have rate limits. Handle them gracefully:
-
-### Detection
-
-Rate limit responses typically appear as:
-- HTTP 429 responses
-- Error messages mentioning "rate limit", "too many requests", or "quota exceeded"
-- Throttled or delayed responses
-
-### Handling
-
-When a source is rate limited:
-
-1. **Do not retry immediately** — respect the limit
-2. **Continue with other sources** — do not block the entire search
-3. **Inform the user**:
-```
-Note: [Source] is temporarily rate limited. Results below are from
-[other sources]. You can retry in a few minutes to include [source].
-```
-4. **For digests** — if rate limited mid-scan, note which time range was covered before the limit hit
-
-### Prevention
-
-- Avoid unnecessary API calls — check if the source is likely to have relevant results before querying
-- Use targeted queries over broad scans when possible
-- For digests, batch requests where the API supports it
-- Cache awareness: if a search was just run, avoid re-running the same query immediately
+**Prevention:** Avoid unnecessary API calls, use targeted queries over broad scans, batch requests for digests, avoid re-running identical queries.
 
 ## Source Health
 
-Track source availability during a session:
-
-```
-Source Status:
-  ~~chat:        ✓ Available
-  ~~email:        ✓ Available
-  ~~cloud storage:  ✓ Available
-  ~~project tracker:        ✗ Not connected
-  ~~CRM:   ✗ Not connected
-  ~~knowledge base:      ⚠ Rate limited (retry in 2 min)
-```
-
-When reporting search results, include which sources were searched so the user knows the scope of the answer.
-
-## Adding Custom Sources
-
-The enterprise search plugin works with any MCP-connected source. As new MCP servers become available, they can be added to the `.mcp.json` configuration. The search and digest commands will automatically detect and include new sources based on available tools.
-
-To add a new source:
-1. Add the MCP server configuration to `.mcp.json`
-2. Authenticate if required
-3. The source will be included in subsequent searches automatically
+When reporting results, include which sources were searched so the user knows the answer's scope. Track availability during a session (available / not connected / rate limited).

--- a/application/plugins/frontend-design/skills/frontend-design/SKILL.md
+++ b/application/plugins/frontend-design/skills/frontend-design/SKILL.md
@@ -1,42 +1,49 @@
 ---
 name: frontend-design
-description: Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, or applications. Generates creative, polished code that avoids generic AI aesthetics.
+description: "Create distinctive, production-grade frontend interfaces with high design quality. Use when the user asks to build a UI, website, landing page, dashboard, HTML page, React component, web component, or any frontend application. Generates creative, polished HTML/CSS/JS or React/Vue code that avoids generic AI aesthetics. Triggers: mentions of .html, .css, .jsx, .tsx, layout, styling, responsive design, or frontend mockup."
 license: Complete terms in LICENSE.txt
 ---
 
-This skill guides creation of distinctive, production-grade frontend interfaces that avoid generic "AI slop" aesthetics. Implement real working code with exceptional attention to aesthetic details and creative choices.
+# Frontend Design
 
-The user provides frontend requirements: a component, page, application, or interface to build. They may include context about the purpose, audience, or technical constraints.
+Build distinctive, production-grade frontend interfaces that avoid generic "AI slop" aesthetics. Deliver real working code with exceptional attention to aesthetic details and creative choices.
 
-## Design Thinking
+## Workflow
 
-Before coding, understand the context and commit to a BOLD aesthetic direction:
-- **Purpose**: What problem does this interface solve? Who uses it?
-- **Tone**: Pick an extreme: brutally minimal, maximalist chaos, retro-futuristic, organic/natural, luxury/refined, playful/toy-like, editorial/magazine, brutalist/raw, art deco/geometric, soft/pastel, industrial/utilitarian, etc. There are so many flavors to choose from. Use these for inspiration but design one that is true to the aesthetic direction.
-- **Constraints**: Technical requirements (framework, performance, accessibility).
-- **Differentiation**: What makes this UNFORGETTABLE? What's the one thing someone will remember?
+### 1. Design Thinking
 
-**CRITICAL**: Choose a clear conceptual direction and execute it with precision. Bold maximalism and refined minimalism both work - the key is intentionality, not intensity.
+Before coding, understand the context and commit to a bold aesthetic direction:
 
-Then implement working code (HTML/CSS/JS, React, Vue, etc.) that is:
-- Production-grade and functional
-- Visually striking and memorable
-- Cohesive with a clear aesthetic point-of-view
-- Meticulously refined in every detail
+1. **Purpose**: What problem does this interface solve? Who uses it?
+2. **Tone**: Choose a distinctive aesthetic — brutally minimal, maximalist, retro-futuristic, organic/natural, luxury/refined, playful, editorial/magazine, brutalist, art deco, soft/pastel, industrial, etc.
+3. **Constraints**: Technical requirements (framework, performance, accessibility).
+4. **Differentiation**: What makes this unforgettable?
 
-## Frontend Aesthetics Guidelines
+Choose a clear conceptual direction and execute it with precision. The key is intentionality, not intensity.
 
-Focus on:
-- **Typography**: Choose fonts that are beautiful, unique, and interesting. Avoid generic fonts like Arial and Inter; opt instead for distinctive choices that elevate the frontend's aesthetics; unexpected, characterful font choices. Pair a distinctive display font with a refined body font.
-- **Color & Theme**: Commit to a cohesive aesthetic. Use CSS variables for consistency. Dominant colors with sharp accents outperform timid, evenly-distributed palettes.
-- **Motion**: Use animations for effects and micro-interactions. Prioritize CSS-only solutions for HTML. Use Motion library for React when available. Focus on high-impact moments: one well-orchestrated page load with staggered reveals (animation-delay) creates more delight than scattered micro-interactions. Use scroll-triggering and hover states that surprise.
-- **Spatial Composition**: Unexpected layouts. Asymmetry. Overlap. Diagonal flow. Grid-breaking elements. Generous negative space OR controlled density.
-- **Backgrounds & Visual Details**: Create atmosphere and depth rather than defaulting to solid colors. Add contextual effects and textures that match the overall aesthetic. Apply creative forms like gradient meshes, noise textures, geometric patterns, layered transparencies, dramatic shadows, decorative borders, custom cursors, and grain overlays.
+### 2. Implementation
 
-NEVER use generic AI-generated aesthetics like overused font families (Inter, Roboto, Arial, system fonts), cliched color schemes (particularly purple gradients on white backgrounds), predictable layouts and component patterns, and cookie-cutter design that lacks context-specific character.
+Implement working code (HTML/CSS/JS, React, Vue, etc.) that is production-grade, visually striking, cohesive, and meticulously refined.
 
-Interpret creatively and make unexpected choices that feel genuinely designed for the context. No design should be the same. Vary between light and dark themes, different fonts, different aesthetics. NEVER converge on common choices (Space Grotesk, for example) across generations.
+### 3. Validation
 
-**IMPORTANT**: Match implementation complexity to the aesthetic vision. Maximalist designs need elaborate code with extensive animations and effects. Minimalist or refined designs need restraint, precision, and careful attention to spacing, typography, and subtle details. Elegance comes from executing the vision well.
+Before delivering, verify:
+- Responsive at mobile, tablet, and desktop breakpoints
+- Animations respect `prefers-reduced-motion`
+- Color contrast meets WCAG AA
+- All interactive elements have hover/focus states
+- No broken asset references or missing fonts
 
-Remember: Claude is capable of extraordinary creative work. Don't hold back, show what can truly be created when thinking outside the box and committing fully to a distinctive vision.
+## Aesthetics Guidelines
+
+- **Typography**: Distinctive, characterful font choices — never Arial, Inter, Roboto, or system defaults. Pair a display font with a refined body font.
+- **Color & Theme**: Cohesive palette via CSS variables. Dominant colors with sharp accents outperform timid, evenly-distributed palettes.
+- **Motion**: CSS-only animations for HTML; Motion library for React. Focus on high-impact moments: one orchestrated page load with staggered `animation-delay` beats scattered micro-interactions. Scroll-triggered and hover surprises.
+- **Spatial Composition**: Unexpected layouts — asymmetry, overlap, diagonal flow, grid-breaking elements, generous negative space or controlled density.
+- **Backgrounds & Depth**: Gradient meshes, noise textures, geometric patterns, layered transparencies, dramatic shadows, decorative borders, grain overlays.
+
+## Anti-Patterns
+
+Never use: overused font families (Inter, Roboto, Space Grotesk), cliched purple gradients on white, predictable component patterns, cookie-cutter designs. Vary between light/dark themes, different fonts, different aesthetics across generations.
+
+Match implementation complexity to the aesthetic vision — maximalist designs need elaborate code; minimalist designs need restraint and precision.

--- a/application/plugins/productivity/skills/memory-management/SKILL.md
+++ b/application/plugins/productivity/skills/memory-management/SKILL.md
@@ -1,82 +1,32 @@
 ---
 name: memory-management
-description: Two-tier memory system that makes Claude a true workplace collaborator. Decodes shorthand, acronyms, nicknames, and internal language so Claude understands requests like a colleague would. CLAUDE.md for working memory, memory/ directory for the full knowledge base.
+description: "Two-tier memory system for workplace collaboration. Use when the user references internal terms, asks to remember something, says 'who is X' or 'what does X mean', needs context from previous conversations, or uses shorthand/acronyms/nicknames. Stores and retrieves people, projects, terms, and preferences across CLAUDE.md (hot cache) and memory/ directory (full knowledge base)."
 ---
 
 # Memory Management
 
-Memory makes Claude your workplace collaborator - someone who speaks your internal language.
-
-## The Goal
-
-Transform shorthand into understanding:
-
-```
-User: "ask todd to do the PSR for oracle"
-              ↓ Claude decodes
-"Ask Todd Martinez (Finance lead) to prepare the Pipeline Status Report
- for the Oracle Systems deal ($2.3M, closing Q2)"
-```
-
-Without memory, that request is meaningless. With memory, Claude knows:
-- **todd** → Todd Martinez, Finance lead, prefers Slack
-- **PSR** → Pipeline Status Report (weekly sales doc)
-- **oracle** → Oracle Systems deal, not the company
-
-## Architecture
-
-```
-CLAUDE.md          ← Hot cache (~30 people, common terms)
-memory/
-  glossary.md      ← Full decoder ring (everything)
-  people/          ← Complete profiles
-  projects/        ← Project details
-  context/         ← Company, teams, tools
-```
-
-**CLAUDE.md (Hot Cache):**
-- Top ~30 people you interact with most
-- ~30 most common acronyms/terms
-- Active projects (5-15)
-- Your preferences
-- **Goal: Cover 90% of daily decoding needs**
-
-**memory/glossary.md (Full Glossary):**
-- Complete decoder ring - everyone, every term
-- Searched when something isn't in CLAUDE.md
-- Can grow indefinitely
-
-**memory/people/, projects/, context/:**
-- Rich detail when needed for execution
-- Full profiles, history, context
+Decode workplace shorthand so requests like "ask todd to do the PSR for oracle" become fully understood actions.
 
 ## Lookup Flow
 
 ```
-User: "ask todd about the PSR for phoenix"
-
-1. Check CLAUDE.md (hot cache)
-   → Todd? ✓ Todd Martinez, Finance
-   → PSR? ✓ Pipeline Status Report
-   → Phoenix? ✓ DB migration project
-
-2. If not found → search memory/glossary.md
-   → Full glossary has everyone/everything
-
-3. If still not found → ask user
-   → "What does X mean? I'll remember it."
+1. CLAUDE.md (hot cache)     → Check first, covers 90% of cases
+2. memory/glossary.md        → Full glossary if not in hot cache
+3. memory/people/, projects/ → Rich detail when needed
+4. Ask user                  → Unknown term? Learn it.
 ```
 
-This tiered approach keeps CLAUDE.md lean (~100 lines) while supporting unlimited scale in memory/.
+## Architecture
 
-## File Locations
-
-- **Working memory:** `CLAUDE.md` in current working directory
-- **Deep memory:** `memory/` subdirectory
+| Location | Contents | Size Target |
+|----------|----------|-------------|
+| `CLAUDE.md` | Top ~30 people, ~30 terms, active projects, preferences | ~50–80 lines |
+| `memory/glossary.md` | Complete decoder ring — everyone, every term | Unlimited |
+| `memory/people/{name}.md` | Full profiles, communication prefs, context | Per person |
+| `memory/projects/{name}.md` | Project details, key people, status | Per project |
+| `memory/context/company.md` | Tools, teams, processes | Company-wide |
 
 ## Working Memory Format (CLAUDE.md)
-
-Use tables for compactness. Target ~50-80 lines total.
 
 ```markdown
 # Memory
@@ -89,7 +39,6 @@ Use tables for compactness. Target ~50-80 lines total.
 |-----|------|
 | **Todd** | Todd Martinez, Finance lead |
 | **Sarah** | Sarah Chen, Engineering (Platform) |
-| **Greg** | Greg Wilson, Sales |
 → Full list: memory/glossary.md, profiles: memory/people/
 
 ## Terms
@@ -97,226 +46,50 @@ Use tables for compactness. Target ~50-80 lines total.
 |------|---------|
 | PSR | Pipeline Status Report |
 | P0 | Drop everything priority |
-| standup | Daily 9am sync |
 → Full glossary: memory/glossary.md
 
 ## Projects
 | Name | What |
 |------|------|
 | **Phoenix** | DB migration, Q2 launch |
-| **Horizon** | Mobile app redesign |
 → Details: memory/projects/
 
 ## Preferences
 - 25-min meetings with buffers
 - Async-first, Slack over email
-- No meetings Friday afternoons
 ```
 
-## Deep Memory Format (memory/)
+## Deep Memory Formats
 
-**memory/glossary.md** - The decoder ring:
-```markdown
-# Glossary
+**memory/glossary.md** — acronyms, internal terms, nicknames, project codenames in table format.
 
-Workplace shorthand, acronyms, and internal language.
+**memory/people/{name}.md** — also-known-as, role, team, reports-to, communication preferences, context, notes. Filename: lowercase hyphens (`todd-martinez.md`).
 
-## Acronyms
-| Term | Meaning | Context |
-|------|---------|---------|
-| PSR | Pipeline Status Report | Weekly sales doc |
-| OKR | Objectives & Key Results | Quarterly planning |
-| P0/P1/P2 | Priority levels | P0 = drop everything |
+**memory/projects/{name}.md** — codename, status, description, key people, context. Filename: lowercase hyphens (`project-phoenix.md`).
 
-## Internal Terms
-| Term | Meaning |
-|------|---------|
-| standup | Daily 9am sync in #engineering |
-| the migration | Project Phoenix database work |
-| ship it | Deploy to production |
-| escalate | Loop in leadership |
+**memory/context/company.md** — tools/systems (with internal names), teams, processes.
 
-## Nicknames → Full Names
-| Nickname | Person |
-|----------|--------|
-| Todd | Todd Martinez (Finance) |
-| T | Also Todd Martinez |
-
-## Project Codenames
-| Codename | Project |
-|----------|---------|
-| Phoenix | Database migration |
-| Horizon | New mobile app |
-```
-
-**memory/people/{name}.md:**
-```markdown
-# Todd Martinez
-
-**Also known as:** Todd, T
-**Role:** Finance Lead
-**Team:** Finance
-**Reports to:** CFO (Michael Chen)
-
-## Communication
-- Prefers Slack DM
-- Quick responses, very direct
-- Best time: mornings
-
-## Context
-- Handles all PSRs and financial reporting
-- Key contact for deal approvals over $500k
-- Works closely with Sales on forecasting
-
-## Notes
-- Cubs fan, likes talking baseball
-```
-
-**memory/projects/{name}.md:**
-```markdown
-# Project Phoenix
-
-**Codename:** Phoenix
-**Also called:** "the migration"
-**Status:** Active, launching Q2
-
-## What It Is
-Database migration from legacy Oracle to PostgreSQL.
-
-## Key People
-- Sarah - tech lead
-- Todd - budget owner
-- Greg - stakeholder (sales impact)
-
-## Context
-$1.2M budget, 6-month timeline. Critical path for Horizon project.
-```
-
-**memory/context/company.md:**
-```markdown
-# Company Context
-
-## Tools & Systems
-| Tool | Used for | Internal name |
-|------|----------|---------------|
-| Slack | Communication | - |
-| Asana | Engineering tasks | - |
-| Salesforce | CRM | "SF" or "the CRM" |
-| Notion | Docs/wiki | - |
-
-## Teams
-| Team | What they do | Key people |
-|------|--------------|------------|
-| Platform | Infrastructure | Sarah (lead) |
-| Finance | Money stuff | Todd (lead) |
-| Sales | Revenue | Greg |
-
-## Processes
-| Process | What it means |
-|---------|---------------|
-| Weekly sync | Monday 10am all-hands |
-| Ship review | Thursday deploy approval |
-```
-
-## How to Interact
-
-### Decoding User Input (Tiered Lookup)
-
-**Always** decode shorthand before acting on requests:
-
-```
-1. CLAUDE.md (hot cache)     → Check first, covers 90% of cases
-2. memory/glossary.md        → Full glossary if not in hot cache
-3. memory/people/, projects/ → Rich detail when needed
-4. Ask user                  → Unknown term? Learn it.
-```
-
-Example:
-```
-User: "ask todd to do the PSR for oracle"
-
-CLAUDE.md lookup:
-  "todd" → Todd Martinez, Finance ✓
-  "PSR" → Pipeline Status Report ✓
-  "oracle" → (not in hot cache)
-
-memory/glossary.md lookup:
-  "oracle" → Oracle Systems deal ($2.3M) ✓
-
-Now Claude can act with full context.
-```
+## Interactions
 
 ### Adding Memory
 
 When user says "remember this" or "X means Y":
-
-1. **Glossary items** (acronyms, terms, shorthand):
-   - Add to memory/glossary.md
-   - If frequently used, add to CLAUDE.md Quick Glossary
-
-2. **People:**
-   - Create/update memory/people/{name}.md
-   - Add to CLAUDE.md Key People if important
-   - **Capture nicknames** - critical for decoding
-
-3. **Projects:**
-   - Create/update memory/projects/{name}.md
-   - Add to CLAUDE.md Active Projects if current
-   - **Capture codenames** - "Phoenix", "the migration", etc.
-
-4. **Preferences:** Add to CLAUDE.md Preferences section
+1. **Terms/acronyms**: Add to `memory/glossary.md`; promote to CLAUDE.md if frequent
+2. **People**: Create/update `memory/people/{name}.md`; add to CLAUDE.md if top 30. Always capture nicknames.
+3. **Projects**: Create/update `memory/projects/{name}.md`; add to CLAUDE.md if active. Capture codenames.
+4. **Preferences**: Add to CLAUDE.md Preferences section
 
 ### Recalling Memory
 
-When user asks "who is X" or "what does X mean":
+Check CLAUDE.md first → `memory/` for full detail → if not found, ask user and learn it.
 
-1. Check CLAUDE.md first
-2. Check memory/ for full detail
-3. If not found: "I don't know what X means yet. Can you tell me?"
+### Promotion / Demotion
 
-### Progressive Disclosure
-
-1. Load CLAUDE.md for quick parsing of any request
-2. Dive into memory/ when you need full context for execution
-3. Example: drafting an email to todd about the PSR
-   - CLAUDE.md tells you Todd = Todd Martinez, PSR = Pipeline Status Report
-   - memory/people/todd-martinez.md tells you he prefers Slack, is direct
+| Action | When |
+|--------|------|
+| Promote to CLAUDE.md | Frequently used, part of active work |
+| Demote to memory/ only | Project completed, person no longer frequent, term rarely used |
 
 ## Bootstrapping
 
-Use `/productivity:start` to initialize by scanning your chat, calendar, email, and documents. Extracts people, projects, and starts building the glossary.
-
-## Conventions
-
-- **Bold** terms in CLAUDE.md for scannability
-- Keep CLAUDE.md under ~100 lines (the "hot 30" rule)
-- Filenames: lowercase, hyphens (`todd-martinez.md`, `project-phoenix.md`)
-- Always capture nicknames and alternate names
-- Glossary tables for easy lookup
-- When something's used frequently, promote it to CLAUDE.md
-- When something goes stale, demote it to memory/ only
-
-## What Goes Where
-
-| Type | CLAUDE.md (Hot Cache) | memory/ (Full Storage) |
-|------|----------------------|------------------------|
-| Person | Top ~30 frequent contacts | glossary.md + people/{name}.md |
-| Acronym/term | ~30 most common | glossary.md (complete list) |
-| Project | Active projects only | glossary.md + projects/{name}.md |
-| Nickname | In Key People if top 30 | glossary.md (all nicknames) |
-| Company context | Quick reference only | context/company.md |
-| Preferences | All preferences | - |
-| Historical/stale | ✗ Remove | ✓ Keep in memory/ |
-
-## Promotion / Demotion
-
-**Promote to CLAUDE.md when:**
-- You use a term/person frequently
-- It's part of active work
-
-**Demote to memory/ only when:**
-- Project completed
-- Person no longer frequent contact
-- Term rarely used
-
-This keeps CLAUDE.md fresh and relevant.
+Use `/productivity:start` to initialize by scanning chat, calendar, email, and documents.


### PR DESCRIPTION
Hey @antoniolg 👋

I ran your skills through `tessl skill review` at work and found some targeted improvements. 

<img width="1312" height="910" alt="image" src="https://github.com/user-attachments/assets/80e1fe0d-7ba2-4ebe-a4bc-a46d3f603e2e" />


Here's the full before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| email | 55% | 100% | +45% |
| justdoit | 69% | 100% | +31% |
| whatsapp-evo | 64% | 94% | +30% |
| youtube-publish | 64% | 89% | +25% |
| weekly-newsletter | 73% | 89% | +16% |

This PR intentionally caps changes at five skills to keep it reviewable. The included GitHub Action workflow will surface Tessl feedback on future `SKILL.md` changes automatically (see below).

<details>
<summary>What changed</summary>

- **email**: Restructured into a clear 4-step workflow (list → open → reply → archive), consolidated reply flags into a scannable table, added proper "Use when…" trigger terms in frontmatter, removed duplicate sections
- **justdoit**: Added concrete workflow examples (morning review, find-and-complete), organized commands into scannable code blocks with context, expanded description with trigger terms
- **whatsapp-evo**: Added error handling guidance (auth failures, connection issues, invalid JIDs), formatted flags as tables, restructured into numbered workflow steps with clear progression
- **youtube-publish**: Consolidated redundant presenter selection instructions (previously in 3 places) into a single section, reorganized agent rules into thematic subsections, fixed YAML frontmatter validation error caused by colons in description
- **weekly-newsletter**: Converted style rules and Listmonk parameters from bullet lists to scannable tables, expanded description with English trigger terms and "Use when…" clause

</details>

## Tessl Skill Review GitHub Action

This PR also adds `.github/workflows/skill-review.yml` — a lightweight workflow that reviews skills automatically on PRs:

- **What runs:** on PRs that change `**/SKILL.md`, [`tesslio/skill-review`](https://github.com/tesslio/skill-review) posts one comment with Tessl scores and feedback (updated on new pushes)
- **Zero extra accounts:** contributors don't need a Tessl login — only `GITHUB_TOKEN` is used to post the comment
- **Non-blocking by default:** the check is feedback-only unless you add `fail-threshold` — no surprise red CI
- **Not a build replacement:** this is review automation for skill markdown only, not a substitute for any existing build pipeline
- **Optional gate:** add `with: fail-threshold: 70` later if you want PRs to fail on low scores
- **Why only five skills here:** keeping this PR small and reviewable; after merge, every PR that touches `SKILL.md` gets automatic review comments, so the rest of the library improves incrementally

---

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me - [@rohan-tessl](https://github.com/rohan-tessl) - if you hit any snags.

Thanks in advance 🙏
